### PR TITLE
Save window size and position between launches

### DIFF
--- a/HackerNews/Base.lproj/Main.storyboard
+++ b/HackerNews/Base.lproj/Main.storyboard
@@ -653,7 +653,7 @@ Gw
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="960" height="540"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1280" height="775"/>
-                        <toolbar key="toolbar" implicitIdentifier="891F2959-8C32-4BB7-AED8-68CD262A6E63" autosavesConfiguration="NO" displayMode="iconOnly" sizeMode="regular" id="Y9G-qJ-Vpx">
+                        <toolbar key="toolbar" implicitIdentifier="891F2959-8C32-4BB7-AED8-68CD262A6E63" displayMode="iconOnly" sizeMode="regular" id="Y9G-qJ-Vpx">
                             <allowedToolbarItems>
                                 <toolbarItem implicitItemIdentifier="NSToolbarSpaceItem" id="TsX-xz-hDT"/>
                                 <toolbarItem implicitItemIdentifier="NSToolbarFlexibleSpaceItem" id="bCq-8x-Ifg"/>

--- a/HackerNews/MainWindowController.swift
+++ b/HackerNews/MainWindowController.swift
@@ -25,6 +25,7 @@ class MainWindowController: NSWindowController {
         MainWindowController.shared = self
         sidebarViewController.delegate = self
         itemListViewController.delegate = self
+        self.windowFrameAutosaveName = "MainAppWindow"
     }
 
     @IBAction func refreshPage(_ sender: NSMenuItem) { pageViewController.refresh(sender) }


### PR DESCRIPTION
Small little change to make the app remember its size & position between launches.

Shamelessly plucked from
https://dev.to/onmyway133/how-to-save-window-size-and-position-in-macos-3e5n
